### PR TITLE
Update "the development guidelines" hyperlink

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 This project is open source, and your contributions are all welcome. There are mostly three different ways one can contribute to the project:
 
 1. use Mailu, either on test or on production instances, and report meaningful bugs when you find some;
-2. contribute code and/or configuration to the repository (see [the development guidelines](https://mailu.io/master/contributors/guide.html) for details);
+2. contribute code and/or configuration to the repository (see [the development guidelines](https://mailu.io/master/contributors/workflow.html) for details);
 3. contribute localization to your native language (see [the localization docs](https://mailu.io/master/contributors/localization.html) for details);
 
 Either way, keep in mind that the code you write or the translation you produce muts be licensed under the same conditions as the project itself. Additionally, all contributors are considered equal co-authors of the project.


### PR DESCRIPTION
"https://mailu.io/master/contributors/guide.html" link get's 404 error (not found). 

## What type of PR?

Documentation

## What does this PR do?

This PR change hyperlink to "https://mailu.io/master/contributors/workflow.html" in CONTRIBUTING.md

### Related issue(s)
- Mention an issue like: #1435
- Auto close an issue like: closes #1435

## Prerequistes
None
